### PR TITLE
moved the common header navigations to resuable class

### DIFF
--- a/pages/headerComponent.ts
+++ b/pages/headerComponent.ts
@@ -1,0 +1,38 @@
+import {Locator, Page} from '@playwright/test';
+
+export class HeaderComponent{
+    private readonly page: Page;
+    readonly appTitle: Locator;
+    readonly homePageLink:Locator;
+    readonly createNewArticleLink: Locator;
+    readonly settingPageLink: Locator;
+    readonly profilePageLink: Locator;
+
+
+    constructor(page:Page){
+        this.page = page;
+        this.appTitle = this.page.locator('navbar-brand');
+        this.homePageLink = this.page.getByRole('link',{name: 'Home'});
+        this.createNewArticleLink = this.page.getByRole('link',{name: 'New Article'});
+        this.settingPageLink = this.page.getByRole('link',{name: 'Settings'});
+        this.profilePageLink = this.page.locator('a[href*="/profile/"]');
+    }
+
+    async getAppTitle(){
+        return this.appTitle.textContent();
+    }
+    async clickHome(){
+        await this.homePageLink.click();
+    }
+    async clickNewArticle(){
+        await this.createNewArticleLink.click();
+    }
+    async clickSettings(){
+        await this.settingPageLink.click();
+    }
+    async clickProfile(){
+        await this.profilePageLink.click();
+    }   
+    
+
+}

--- a/pages/homePage.ts
+++ b/pages/homePage.ts
@@ -1,5 +1,6 @@
 import {Page} from '@playwright/test'
 import { Locator } from '@playwright/test';
+import { HeaderComponent } from './headerComponent';
 
 
 export class HomePage{
@@ -10,6 +11,7 @@ export class HomePage{
     private articlesList: Locator;
     private homePageMenu:   Locator;
     private articlesTag:Locator;
+    readonly header: HeaderComponent;
 
     constructor(page:Page){
         this.page   =   page;
@@ -18,6 +20,7 @@ export class HomePage{
         this.articlesList   =   this.page.locator('div.article-preview h1');
         this.homePageMenu   =   this.page.locator('.navbar-nav li');
         this.articlesTag    =   this.page.locator('ul.tag-list');
+        this.header = new HeaderComponent(this.page);
     }
     async getTagsCount(tagValue:string){
         let countOfExitingTags=0;
@@ -28,11 +31,6 @@ export class HomePage{
             }
         }
         return countOfExitingTags;
-    }
-
-
-    async clickOnNewArticle(){
-        await this.newArticleLink.click();
     }
 
     getFirstArticleOnTheList(){

--- a/tests/ui/createArticleTest.spec.ts
+++ b/tests/ui/createArticleTest.spec.ts
@@ -18,7 +18,7 @@ test.beforeEach(async({loginPage,page})=>{
 })
 test('should be able to create a new article without tags successfully',async({createArticlePage, homePage, articlePage, page})=>{
     const article = generateArticle('basic');
-    await homePage.clickOnNewArticle();
+    await homePage.header.clickNewArticle();
     const createArticleResponsePromise = page.waitForResponse(response =>
     response.url().includes('/api/articles') &&
     response.request().method() === 'POST'
@@ -32,7 +32,7 @@ test('should be able to create a new article without tags successfully',async({c
 })
 test('should be able to create a new article with a single tag successfully',async({homePage, createArticlePage, articlePage, page})=>{
     const article = generateArticle('oneTag');
-    await homePage.clickOnNewArticle()
+    await homePage.header.clickNewArticle();
     const createArticleResponsePromise = page.waitForResponse(response =>
     response.url().includes('/api/articles') &&
     response.request().method() === 'POST'
@@ -53,7 +53,7 @@ test('should be able to create a new article with a single tag successfully',asy
 })
 test('should be able to create a new article with multiple tags successfully',async({createArticlePage, homePage, articlePage, page})=>{
     const article = generateArticle('multiTag');
-    await homePage.clickOnNewArticle();
+    await homePage.header.clickNewArticle();
     const createArticleResponsePromise = page.waitForResponse(response =>
     response.url().includes('/api/articles') &&
     response.request().method() === 'POST'
@@ -71,7 +71,7 @@ test('should be able to create a new article with multiple tags successfully',as
 })
 test('should be able to create a new article with already existing tags successfully',async({homePage, page, createArticlePage, articlePage})=>{
     const article = generateArticle('existingTags');
-    await homePage.clickOnNewArticle();
+    await homePage.header.clickNewArticle();
     const createArticleResponsePromise = page.waitForResponse(response =>
     response.url().includes('/api/articles') &&
     response.request().method() === 'POST'

--- a/tests/ui/deleteArticleTest.spec.ts
+++ b/tests/ui/deleteArticleTest.spec.ts
@@ -4,7 +4,7 @@ import { generateArticle } from '../../test-data/articles';
 test.beforeEach(async({loginPage,page, homePage})=>{
     await page.goto('/');
     await loginPage.loginWithEmailAndPassword('playwright_automation@test.com','Automation1')
-    await homePage.clickOnNewArticle()
+    await homePage.header.clickNewArticle();
     
 })
 

--- a/tests/ui/editArticleTest.spec.ts
+++ b/tests/ui/editArticleTest.spec.ts
@@ -18,7 +18,7 @@ test.beforeEach(async({loginPage, page, homePage, createArticlePage, articlePage
     const loginResponse = await loginResponsePromise;
     const loginResponseBody = await loginResponse.json();
     token = loginResponseBody.user.token;
-    await homePage.clickOnNewArticle();
+    await homePage.header.clickNewArticle();
     const createArticleResponsePromise = page.waitForResponse(response =>
     response.url().includes('/api/articles') &&
     response.request().method() === 'POST'

--- a/tests/ui/listArticles.spec.ts
+++ b/tests/ui/listArticles.spec.ts
@@ -16,7 +16,7 @@ test.describe('Verifies the articles listed',()=>{
         expect(verifyArticleTag).toBeTruthy();
     })
 
-    test('should verify the number of likes in an article',async({homePage, createArticlePage, articlePage, page})=>{
+    test('should verify the number of likes in an article',async({homePage})=>{
         const firstArticle  =   homePage.getFirstArticleOnTheList();
         expect(firstArticle).not.toBeNull();
         const firstArticleTitle = await firstArticle.textContent();


### PR DESCRIPTION
This PR improves reusability by moving the common header navigations to a base class and then using this class objects in each page objects to call the respective method